### PR TITLE
Correctly processes amounts with one decimal

### DIFF
--- a/lib/pages/transaction.dart
+++ b/lib/pages/transaction.dart
@@ -378,20 +378,26 @@ class _TransactionPageState extends State<TransactionPage>
               // extract amount
               // Check if string has a decimal separator
               final String amountStr = validMatch.namedGroup("amount") ?? "";
+              final int decimalSepPos = 
+                  amountStr.length >= 3 &&
+                  (amountStr[amountStr.length - 3] == "." ||
+                  amountStr[amountStr.length - 3] == ",") ?
+                  amountStr.length - 3 : amountStr.length - 2;
               final String decimalSep =
-                  amountStr.length >= 3 ? amountStr[amountStr.length - 3] : "";
+                  amountStr.length >= decimalSepPos && decimalSepPos > 0 ? 
+                  amountStr[decimalSepPos] : "";
               if (decimalSep == "," || decimalSep == ".") {
                 final double wholes = double.tryParse(amountStr
-                        .substring(0, amountStr.length - 3)
+                        .substring(0, decimalSepPos)
                         .replaceAll(",", "")
                         .replaceAll(".", "")) ??
                     0;
-                final double dec = double.tryParse(amountStr
-                        .substring(amountStr.length - 2)
+                final String decStr = amountStr
+                        .substring(decimalSepPos + 1)
                         .replaceAll(",", "")
-                        .replaceAll(".", "")) ??
-                    0;
-                amount = wholes + dec / 100;
+                        .replaceAll(".", "");
+                final double dec = double.tryParse(decStr) ?? 0;
+                amount = decStr.length == 1 ? wholes + dec / 10 : wholes + dec / 100;
               } else {
                 amount = double.tryParse(
                         amountStr.replaceAll(",", "").replaceAll(".", "")) ??


### PR DESCRIPTION
My banking app always omits the trailing zero in the amount inside my transactions notifications, for example:

![image](https://github.com/dreautall/waterfly-iii/assets/11351405/7ebb55b7-6fd0-464b-bb12-9fc06821c538)

This gets falsely interpreted as 132 RON instead of 13.2 RON by Waterfly.
I tried correcting it myself and this is what I came up with. 
I'm sorry if it's not the best solution, it's my first time doing this.
I hope the PR was correctly made too, it's also my first time doing this :)