### PR TITLE
Adds whitespace into amount regexp part

### DIFF
--- a/lib/notificationlistener.dart
+++ b/lib/notificationlistener.dart
@@ -52,7 +52,7 @@ class NotificationListenerStatus {
 }
 
 final RegExp rFindMoney = RegExp(
-    r'(?:^|\s)(?<preCurrency>(?:[^\r\n\t\f\v 0-9]){0,3})\s*(?<amount>[.,\d]+(?:[.,]\d+)?)\s*(?<postCurrency>(?:[^\r\n\t\f\v 0-9]){0,3})(?:$|\s)');
+    r'(?:^|\s)(?<preCurrency>(?:[^\r\n\t\f\v 0-9]){0,3})\s*(?<amount>[.,\s\d]+(?:[.,]\d+)?)\s*(?<postCurrency>(?:[^\r\n\t\f\v 0-9]){0,3})(?:$|\s)');
 
 Future<NotificationListenerStatus> nlStatus() async {
   return NotificationListenerStatus(


### PR DESCRIPTION
Some locales have a space as a thousands separator. This should pick amount with space inside too.