### PR TITLE
Fixed transaction screen only showing the first 50 tags

### DIFF
--- a/lib/pages/transaction/tags.dart
+++ b/lib/pages/transaction/tags.dart
@@ -155,7 +155,7 @@ class _TagDialogState extends State<TagDialog> {
   Future<List<String>>? _getTags() async {
     final FireflyIii api = context.read<FireflyService>().api;
     List<String> tags = <String>[];
-    Response<TagArray> response;
+    late Response<TagArray> response;
     int pageNumber = 0;
 
     do {
@@ -177,8 +177,8 @@ class _TagDialogState extends State<TagDialog> {
       }
 
       tags.addAll(response.body!.data.map((TagRead e) => e.attributes.tag));
-    } while (response.body!.meta.pagination!.currentPage! <
-        response.body!.meta.pagination!.totalPages!);
+    } while ((response.body!.meta.pagination?.currentPage ?? 1) <
+        (response.body!.meta.pagination?.totalPages ?? 1));
 
     return tags;
   }


### PR DESCRIPTION
### Changelog
Added pagination to fetch all tags when editing a transaction.
### Test
Previously only the first 50 (default value) tags were fetched. On my current instance that meant somewhere up to the "P"-s:

<img src="https://github.com/dreautall/waterfly-iii/assets/111386682/4e398af6-d649-4265-a2b8-e018af1da0e8" width="250">

With pagination it now fetches all tags:

<img src="https://github.com/dreautall/waterfly-iii/assets/111386682/30c08752-a490-4dc6-9fa8-0d6210e8dbc5" width="250">
