### PR TITLE
Saving selected bill

### DIFF
--- a/lib/pages/transaction.dart
+++ b/lib/pages/transaction.dart
@@ -966,10 +966,7 @@ class _TransactionPageState extends State<TransactionPage>
                         }
                         txS.add(TransactionSplitUpdate(
                           amount: _localAmounts[i].toString(),
-                          billId: _bills[i] != null
-                              ? _bills[i]!.id
-                              : '0',
-                          billName: _bills[i]?.attributes.name,
+                          billId: _bills[i]?.id ?? "0",
                           budgetName: (_transactionType ==
                                   TransactionTypeProperty.withdrawal)
                               ? _budgetTextControllers[i].text
@@ -1048,10 +1045,7 @@ class _TransactionPageState extends State<TransactionPage>
                           description: _split
                               ? _titleTextControllers[i].text
                               : _titleTextController.text,
-                          billId: _bills[i] != null
-                              ? _bills[i]!.id
-                              : '0',
-                          billName: _bills[i]?.attributes.name,
+                          billId: _bills[i]?.id ?? "0",
                           budgetName: (_transactionType ==
                                   TransactionTypeProperty.withdrawal)
                               ? _budgetTextControllers[i].text


### PR DESCRIPTION
### Changelog
Made sure the selected bill details for a transaction are passed to the API.
### Test
The current prod version does not pass the selected bill details to the create/update API call when a transaction is saved. The UI shows a bill selected until the transaction view is closed after saving, but opening it again in the app or in the Firefly III web UI will show the field empty. The information was already stored in memory, it simply needed to be passed to the API call. It now works like a charm.