### PR TITLE
Fix dead documentation link

### DIFF
--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -268,7 +268,7 @@ class _LoginPageState extends State<LoginPage> {
                       OutlinedButton(
                         onPressed: () async {
                           final Uri uri = Uri.parse(
-                              "https://docs.firefly-iii.org/firefly-iii/api/#personal-access-token");
+                              "https://docs.firefly-iii.org/how-to/firefly-iii/features/api/#personal-access-tokens");
                           if (await canLaunchUrl(uri)) {
                             await launchUrl(uri);
                           } else {


### PR DESCRIPTION
The 'Help' button in the login screen leads to a 404, I have replaced it with the correct URL.

- Current - https://docs.firefly-iii.org/firefly-iii/api/#personal-access-token
- Updated - https://docs.firefly-iii.org/how-to/firefly-iii/features/api/#personal-access-tokens