### PR TITLE
 Fixed perpetual loading state of add transaction view 

### DIFF
--- a/lib/pages/transaction.dart
+++ b/lib/pages/transaction.dart
@@ -41,7 +41,6 @@ class TransactionPage extends StatefulWidget {
   const TransactionPage({
     super.key,
     this.transaction,
-    this.transactionId,
     this.notification,
     this.files,
     this.clone = false,


### PR DESCRIPTION
Removed no longer needed case of displaying loading indicator.
Prior to the bills page work, it was planned to add an option to open a transaction edit view by providing the transaction id. This was removed, however one condition was left in, which prevented the view to initialize properly when the user wanted to create a new transaction.