### PR TITLE
fix(feature/77): use CronetClient instance for auth request

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,21 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.dreautall.waterflyiii">
-    <application android:label="Waterfly III" android:name="${applicationName}" android:icon="@mipmap/ic_launcher" android:enableOnBackInvokedCallback="false" android:usesCleartextTraffic="true" android:networkSecurityConfig="@xml/network_security_config">
-        <activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
+    <application
+            android:label="Waterfly III"
+            android:name="${applicationName}"
+            android:icon="@mipmap/ic_launcher"
+            android:enableOnBackInvokedCallback="false"
+            android:usesCleartextTraffic="true"
+            android:networkSecurityConfig="@xml/network_security_config"
+    >
+        <activity
+                android:name=".MainActivity"
+                android:exported="true"
+                android:launchMode="singleTop"
+                android:theme="@style/LaunchTheme"
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+                android:hardwareAccelerated="true"
+                android:windowSoftInputMode="adjustResize"
+        >
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -176,7 +176,7 @@ class AuthUser {
       final http.Request request = http.Request(HttpMethod.Get, aboutUri);
       request.headers[HttpHeaders.authorizationHeader] = "Bearer $apiKey";
       request.followRedirects = false;
-      final http.StreamedResponse response = await request.send();
+      final http.StreamedResponse response = await client.send(request);
 
       if (response.isRedirect) {
         throw const AuthErrorApiKey();

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -94,7 +94,10 @@ class AuthErrorNoInstance extends AuthError {
   final String host;
 }
 
-http.Client get httpClient => CronetClient.defaultCronetEngine();
+http.Client get httpClient => CronetClient.fromCronetEngine(
+  CronetEngine.build(),
+  closeEngine: false
+);
 
 class APIRequestInterceptor implements Interceptor {
   APIRequestInterceptor(this.headerFunc);

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -53,25 +53,6 @@ class APITZReplyData {
   }
 }
 
-class SSLHttpOverride extends HttpOverrides {
-  SSLHttpOverride(this.validCert);
-  final String validCert;
-
-  @override
-  HttpClient createHttpClient(SecurityContext? context) {
-    // Needed for issue #75
-    //context ??= SecurityContext.defaultContext;
-    //context.useCertificateChainBytes(chainBytes);
-    //context.usePrivateKeyBytes(keyBytes);
-    return super.createHttpClient(context)
-      ..badCertificateCallback = (X509Certificate cert, _, __) {
-        log.fine("Using SSLHttpOverride");
-        return cert.pem.replaceAll("\r", "").trim() ==
-            validCert.replaceAll("\r", "").trim();
-      };
-  }
-}
-
 // :TODO: translate strings. cause returns just an identifier for the translation.
 class AuthError implements Exception {
   const AuthError(this.cause);


### PR DESCRIPTION
This PR fixes a misconfigured HTTP request during the initial auth check, as well as removes the custom `SSLHttpOverrides` class.
Additional refactoring of the manifest for easier reading.

This should resolve the base PR issue by accepting user-installed CA certificates on the device.

Tested on my Samsung S22.