### PR TITLE
Align NumberInput to DateTimePicker

### DIFF
--- a/lib/pages/transaction.dart
+++ b/lib/pages/transaction.dart
@@ -1283,27 +1283,29 @@ class _TransactionPageState extends State<TransactionPage>
           children: <Widget>[
             SizedBox(
               width: 130,
-              child: NumberInput(
-                icon:
-                    _localCurrency != null
-                        ? SizedBox(
-                          width: 24,
-                          height: 32,
-                          child: FittedBox(
-                            child: Text(_localCurrency!.attributes.symbol),
-                          ),
-                        )
-                        : Icon(Icons.monetization_on),
-                hintText:
-                    _localCurrency?.zero() ??
-                    NumberFormat.currency(decimalDigits: 2).format(0),
-                decimals: _localCurrency?.attributes.decimalPlaces ?? 2,
-                //style: Theme.of(context).textTheme.headlineLarge,
-                controller: _localAmountTextController,
-                disabled: _split || (_reconciled && _initiallyReconciled),
-                onChanged:
-                    (String string) =>
-                        _localAmounts[0] = double.tryParse(string) ?? 0,
+              child: Center(
+                child: NumberInput(
+                  icon:
+                      _localCurrency != null
+                          ? SizedBox(
+                            width: 24,
+                            height: 32,
+                            child: FittedBox(
+                              child: Text(_localCurrency!.attributes.symbol),
+                            ),
+                          )
+                          : Icon(Icons.monetization_on),
+                  hintText:
+                      _localCurrency?.zero() ??
+                      NumberFormat.currency(decimalDigits: 2).format(0),
+                  decimals: _localCurrency?.attributes.decimalPlaces ?? 2,
+                  //style: Theme.of(context).textTheme.headlineLarge,
+                  controller: _localAmountTextController,
+                  disabled: _split || (_reconciled && _initiallyReconciled),
+                  onChanged:
+                      (String string) =>
+                          _localAmounts[0] = double.tryParse(string) ?? 0,
+                ),
               ),
             ),
             vDivider,


### PR DESCRIPTION
Fix vertical alignment for the NumberInput to make it perfectly in-line with the DateTimePicker.