### PR TITLE
Added clear button to auto-complete text fields

### DIFF
--- a/lib/widgets/autocompletetext.dart
+++ b/lib/widgets/autocompletetext.dart
@@ -87,11 +87,7 @@ class _AutoCompleteTextState<T extends Object> extends State<AutoCompleteText<T>
                 ) => TextFormField(
                   controller: textEditingController,
                   focusNode: focusNode,
-                  onChanged: (e) => setState(() {
-                    if (widget.onChanged != null) {
-                      widget.onChanged!(e);
-                    }
-                  }),
+                  onChanged: widget.onChanged,
                   readOnly: widget.disabled,
                   enabled: !widget.disabled,
                   decoration: InputDecoration(


### PR DESCRIPTION
### Changelog
- Clear button is displayed on auto-complete text fields once the user inputs some text or selects an item from the auto-complete list.
- Clicking the clear button will erase the contents of the field and move the focus to the control.
- Ensured transaction type update logic is triggered when the clear button is interacted with on the source/destination account fields.
### Screenshots
Initial state:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/64e45574-931d-4338-89f3-f058846e1bd6" />
User entered/selected some value:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/8faa02a6-0f9a-4737-815b-12aa26f2c8c8" />
Clicking the clear button sets focus and shows the dropdown again:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e4f44bc0-d233-45cd-834e-1be86f3d6aec" />
User entered/selected a source account:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c171c684-2348-4aa6-b034-9d395e37b319" />
User clicked the clear button and closed the dropdown:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ecd7da97-0df5-4f6b-9169-c90a868d23f5" />
Observe how the transaction type indicator is updated in both screenshots.