### PR TITLE
Fixed faulty bills filtering

### DIFF
--- a/lib/pages/bills.dart
+++ b/lib/pages/bills.dart
@@ -356,188 +356,196 @@ class _BillsPageState extends State<BillsPage>
     }
 
     // Bill not expected this period
-    return TextSpan(text: S.of(context).billsNotExpected);
+    return TextSpan(
+      text: S.of(context).billsNotExpected,
+      style: Theme.of(context).textTheme.bodySmall,
+    );
   }
 
   void _showLayoutPickerDialog() => showModalBottomSheet<void>(
     context: context,
-    builder: (BuildContext context) => SafeArea(
-      child: SingleChildScrollView(
-        child: ListBody(
-          children: <Widget>[
-            const SizedBox(height: 8),
-            ListTile(
-              leading:
-              _billsLayout == BillsLayout.grouped
-                  ? const Icon(Icons.view_agenda)
-                  : const Icon(Icons.view_agenda_outlined),
-              title: Text(
-                S.of(context).billsLayoutGroupTitle,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-              ),
-              subtitle: Text(
-                S.of(context).billsLayoutGroupSubtitle,
-                style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                  color: Theme.of(context).colorScheme.secondary,
+    builder:
+        (BuildContext context) => SafeArea(
+          child: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                const SizedBox(height: 8),
+                ListTile(
+                  leading:
+                      _billsLayout == BillsLayout.grouped
+                          ? const Icon(Icons.view_agenda)
+                          : const Icon(Icons.view_agenda_outlined),
+                  title: Text(
+                    S.of(context).billsLayoutGroupTitle,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).billsLayoutGroupSubtitle,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing:
+                      _billsLayout == BillsLayout.grouped
+                          ? const Icon(Icons.check)
+                          : const SizedBox.shrink(),
+                  onTap:
+                      () => setState(() {
+                        _billsLayout = BillsLayout.grouped;
+                        Navigator.pop(context);
+                      }),
                 ),
-              ),
-              trailing:
-              _billsLayout == BillsLayout.grouped
-                  ? const Icon(Icons.check)
-                  : const SizedBox.shrink(),
-              onTap:
-                  () => setState(() {
-                _billsLayout = BillsLayout.grouped;
-                Navigator.pop(context);
-              }),
-            ),
-            const Divider(indent: 8, endIndent: 8),
-            ListTile(
-              leading:
-              _billsLayout == BillsLayout.list
-                  ? const Icon(Icons.table_rows)
-                  : const Icon(Icons.table_rows_outlined),
-              title: Text(
-                S.of(context).billsLayoutListTitle,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-              ),
-              subtitle: Text(
-                S.of(context).billsLayoutListSubtitle,
-                style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                  color: Theme.of(context).colorScheme.secondary,
+                const Divider(indent: 8, endIndent: 8),
+                ListTile(
+                  leading:
+                      _billsLayout == BillsLayout.list
+                          ? const Icon(Icons.table_rows)
+                          : const Icon(Icons.table_rows_outlined),
+                  title: Text(
+                    S.of(context).billsLayoutListTitle,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).billsLayoutListSubtitle,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing:
+                      _billsLayout == BillsLayout.list
+                          ? const Icon(Icons.check)
+                          : const SizedBox.shrink(),
+                  onTap:
+                      () => setState(() {
+                        _billsLayout = BillsLayout.list;
+                        _billsSort = BillsSort.name;
+                        _billsSortOrder = SortingOrder.ascending;
+                        Navigator.pop(context);
+                      }),
                 ),
-              ),
-              trailing:
-              _billsLayout == BillsLayout.list
-                  ? const Icon(Icons.check)
-                  : const SizedBox.shrink(),
-              onTap:
-                  () => setState(() {
-                _billsLayout = BillsLayout.list;
-                _billsSort = BillsSort.name;
-                _billsSortOrder = SortingOrder.ascending;
-                Navigator.pop(context);
-              }),
+                const SizedBox(height: 8),
+              ],
             ),
-            const SizedBox(height: 8),
-          ],
+          ),
         ),
-      ),
-    ),
   );
 
   void _showSortOrderPickerDialog() => showModalBottomSheet<void>(
     context: context,
-    builder: (BuildContext context) => SafeArea(
-      child: SingleChildScrollView(
-        child: ListBody(
-          children: <Widget>[
-            const SizedBox(height: 8),
-            ListTile(
-              leading: const Icon(Icons.sort),
-              title: Text(
-                S.of(context).billsSortName,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-              ),
-              subtitle: Text(
-                S.of(context).billsSortAlphabetical,
-                style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                  color: Theme.of(context).colorScheme.secondary,
+    builder:
+        (BuildContext context) => SafeArea(
+          child: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                const SizedBox(height: 8),
+                ListTile(
+                  leading: const Icon(Icons.sort),
+                  title: Text(
+                    S.of(context).billsSortName,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).billsSortAlphabetical,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing:
+                      _billsSort == BillsSort.name
+                          ? _billsSortOrder == SortingOrder.ascending
+                              ? const Icon(Icons.north)
+                              : const Icon(Icons.south)
+                          : const SizedBox.shrink(),
+                  onTap: () => _onSortSelected(BillsSort.name),
                 ),
-              ),
-              trailing:
-              _billsSort == BillsSort.name
-                  ? _billsSortOrder == SortingOrder.ascending
-                  ? const Icon(Icons.north)
-                  : const Icon(Icons.south)
-                  : const SizedBox.shrink(),
-              onTap: () => _onSortSelected(BillsSort.name),
-            ),
-            const Divider(indent: 8, endIndent: 8),
-            ListTile(
-              leading: const Icon(Icons.sort),
-              title: Text(
-                S.of(context).billsSortFrequency,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-              ),
-              subtitle: Text(
-                S.of(context).billsSortByTimePeriod,
-                style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                  color: Theme.of(context).colorScheme.secondary,
+                const Divider(indent: 8, endIndent: 8),
+                ListTile(
+                  leading: const Icon(Icons.sort),
+                  title: Text(
+                    S.of(context).billsSortFrequency,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).billsSortByTimePeriod,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing:
+                      _billsSort == BillsSort.frequency
+                          ? _billsSortOrder == SortingOrder.ascending
+                              ? const Icon(Icons.north)
+                              : const Icon(Icons.south)
+                          : const SizedBox.shrink(),
+                  onTap: () => _onSortSelected(BillsSort.frequency),
                 ),
-              ),
-              trailing:
-              _billsSort == BillsSort.frequency
-                  ? _billsSortOrder == SortingOrder.ascending
-                  ? const Icon(Icons.north)
-                  : const Icon(Icons.south)
-                  : const SizedBox.shrink(),
-              onTap: () => _onSortSelected(BillsSort.frequency),
+                const SizedBox(height: 8),
+              ],
             ),
-            const SizedBox(height: 8),
-          ],
+          ),
         ),
-      ),
-    )
   );
 
   void _showSettingsDialog() => showModalBottomSheet<void>(
-      context: context,
-      builder: (BuildContext context) => SafeArea(
-        child: SingleChildScrollView(
-          child: ListBody(
-            children: <Widget>[
-              const SizedBox(height: 8),
-              ListTile(
-                leading: const Icon(Icons.visibility),
-                title: Text(
-                  S.of(context).billsSettingsShowOnlyActive,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-                ),
-                subtitle: Text(
-                  S.of(context).billsSettingsShowOnlyActiveDesc,
-                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                    color: Theme.of(context).colorScheme.secondary,
+    context: context,
+    builder:
+        (BuildContext context) => SafeArea(
+          child: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                const SizedBox(height: 8),
+                ListTile(
+                  leading: const Icon(Icons.visibility),
+                  title: Text(
+                    S.of(context).billsSettingsShowOnlyActive,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).billsSettingsShowOnlyActiveDesc,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing: Switch(
+                    value: _showOnlyActiveBills,
+                    onChanged: _onShowOnlyActiveBillsToggled,
                   ),
                 ),
-                trailing: Switch(
-                  value: _showOnlyActiveBills,
-                  onChanged: _onShowOnlyActiveBillsToggled),
-              ),
-              const Divider(indent: 8, endIndent: 8),
-              ListTile(
-                leading: const Icon(Icons.visibility),
-                title: Text(
-                  S.of(context).billsSettingsShowOnlyExpected,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.bold),
-                ),
-                subtitle: Text(
-                  S.of(context).billsSettingsShowOnlyExpectedDesc,
-                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                    color: Theme.of(context).colorScheme.secondary,
+                const Divider(indent: 8, endIndent: 8),
+                ListTile(
+                  leading: const Icon(Icons.visibility),
+                  title: Text(
+                    S.of(context).billsSettingsShowOnlyExpected,
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
-                ),
-                trailing: Switch(
+                  subtitle: Text(
+                    S.of(context).billsSettingsShowOnlyExpectedDesc,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  trailing: Switch(
                     value: _showOnlyExpectedBills,
-                    onChanged: _onShowOnlyExpectedBillsToggled),
-              ),
-              const SizedBox(height: 8),
-            ],
+                    onChanged: _onShowOnlyExpectedBillsToggled,
+                  ),
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
           ),
         ),
-      ),
   );
 
   void _onShowOnlyActiveBillsToggled(bool value) {
@@ -605,7 +613,9 @@ class _BillsPageState extends State<BillsPage>
         continue;
       }
 
-      if (_showOnlyExpectedBills && bill.attributes.nextExpectedMatch == null) {
+      if (_showOnlyExpectedBills &&
+          bill.attributes.nextExpectedMatch == null &&
+          bill.attributes.paidDates!.isEmpty) {
         // Do not show the bill if it is not expected this cycle and the user
         // elected to hide all those bills that are not expected
         continue;
@@ -613,9 +623,7 @@ class _BillsPageState extends State<BillsPage>
 
       final String key =
           bill.attributes.objectGroupTitle ??
-              (mounted ? S
-                  .of(context)
-                  .billsUngrouped : "");
+          (mounted ? S.of(context).billsUngrouped : "");
       if (!billsMap.containsKey(key)) {
         billsMap[key] = <BillRead>[];
       }


### PR DESCRIPTION
### Changelog
- Fixed an issue where bills paid this period would not show up if the `Show only expected` filter is turned on. 
- Fixed `Not expected this period` text rendering with different text size than other status strings.
- Formatted `bills.dart`.
### Screenshots
Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c112f4ca-d6e9-4050-aa98-52e396041868" />
After:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5a54fcc0-e697-439f-a95a-92706ec305d8" />
