### PR TITLE
Feature: Add custom regex option for each app in notification listener

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,0 +1,122 @@
+name: Build
+
+on:
+  workflow_dispatch: 
+  release:
+    types:
+      - created
+  push:
+    branches:
+      - develop
+
+env:
+  PROPERTIES_PATH: "./android/key.properties"
+
+jobs:
+  # check:
+  #   uses: ./.github/workflows/commit.yml
+  #   name: codecheck
+
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip build]') }}
+    # needs: [check]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Call setup_env action to setup workspace
+      - uses: ./.github/actions/setup_env
+        with:
+          java-version: 17.x
+          flutter-channel: stable
+
+      # Generate keystore
+      - uses: timheuer/base64-to-file@v1.2
+        id: android_keystore
+        with:
+          fileName: upload-keystore.jks
+          encodedString: ${{ secrets.KEYSTORE_BASE64 }}
+
+      - run: |
+          flutter pub run rename setBundleId --value "com.waterflyiii.test" --targets android
+
+      # Create key.properties
+      - run: |
+          echo "storeFile=${{ steps.android_keystore.outputs.filePath }}" > ${{env.PROPERTIES_PATH}}
+          echo "storePassword=${{ secrets.STORE_PASSWORD }}" >> ${{env.PROPERTIES_PATH}}
+          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> ${{env.PROPERTIES_PATH}}
+          echo "keyAlias=upload" >> ${{env.PROPERTIES_PATH}}
+
+      # Set build number
+      - run: |
+          sed -i 's/^\(version: [0-9\.]\{1,\}\(-[a-z]\{1,\}\)\{0,1\}\([0-9\.]\)\{0,\}\)$/\1+${{ github.run_number }}/m' pubspec.yaml
+
+      # Build l10n files
+      - run: mkdir -p build && flutter gen-l10n
+
+      # Build apk.
+      - run: flutter build apk --release --split-per-abi --target-platform android-arm64 --dart-define=cronetHttpNoPlay=true
+     # - run: flutter build apk --obfuscate --split-debug-info=build/app/outputs/symbols/apk --release --split-per-abi --target-platform android-arm64 --dart-define=cronetHttpNoPlay=true
+
+      # Build aab
+      # Since the aab is only distributed to the play store and never uploaded somewhere else, we can use the Google Play Services cronet here.
+    #  - run: flutter build appbundle --obfuscate --split-debug-info=build/app/outputs/symbols/aab --release
+
+      # Zip symbols
+     # - uses: montudor/action-zip@v1
+     # - run: zip -qq -r aab-debug-symbols.zip *
+      #  working-directory: build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/
+
+      # Upload generated apk to the artifacts.
+      - uses: actions/upload-artifact@v5
+        with:
+          name: app-arm64-v8a-release.apk
+          path: build/app/outputs/apk/release/app-arm64-v8a-release.apk
+    #  - uses: actions/upload-artifact@v5
+      #  with:
+     #     name: app-armeabi-v7a-release.apk
+    #      path: build/app/outputs/apk/release/app-armeabi-v7a-release.apk
+      #- uses: actions/upload-artifact@v5
+    #    with:
+    #      name: app-x86_64-release.apk
+    #      path: build/app/outputs/flutter-apk/app-x86_64-release.apk
+
+     # - uses: actions/upload-artifact@v5
+     #   with:
+     #     name: app-release.aab
+      #    path: build/app/outputs/bundle/release/app-release.aab
+     # - uses: actions/upload-artifact@v5
+     #   with:
+    #      name: aab-debug-symbols.zip
+      #    path: build/app/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/aab-debug-symbols.zip
+      - uses: actions/upload-artifact@v5
+        with:
+          name: mapping.txt
+          path: build/app/outputs/mapping/release/mapping.txt
+
+  upload-to-github:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: app-arm64-v8a-release.apk
+          path: ./artifacts
+      - uses: actions/download-artifact@v6
+        with:
+          name: app-armeabi-v7a-release.apk
+          path: ./artifacts
+      - uses: actions/download-artifact@v6
+        with:
+          name: app-x86_64-release.apk
+          path: ./artifacts
+      
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./artifacts/app-arm64-v8a-release.apk
+            ./artifacts/app-armeabi-v7a-release.apk
+            ./artifacts/app-x86_64-release.apk

--- a/lib/notificationlistener.dart
+++ b/lib/notificationlistener.dart
@@ -72,6 +72,8 @@ void nlCallback() {
   NotificationServicePlugin.instance.executeNotificationListener((
     NotificationEvent? evt,
   ) async {
+    WidgetsFlutterBinding.ensureInitialized();
+
     if (evt == null || evt.packageName == null) {
       return;
     }
@@ -81,28 +83,33 @@ void nlCallback() {
     if (evt.state == NotificationState.remove) {
       return;
     }
-    final Iterable<RegExpMatch> matches = rFindMoney.allMatches(evt.text ?? "");
-    if (matches.isEmpty) {
-      log.finer(() => "nlCallback(${evt.packageName}): no money found");
-      return;
-    }
-
-    bool validMatch = false;
-    for (RegExpMatch match in matches) {
-      if ((match.namedGroup("postCurrency")?.isNotEmpty ?? false) ||
-          (match.namedGroup("preCurrency")?.isNotEmpty ?? false)) {
-        validMatch = true;
-        break;
-      }
-    }
-    if (!validMatch) {
-      log.finer(
-        () => "nlCallback(${evt.packageName}): no money with currency found",
-      );
-      return;
-    }
 
     final SettingsProvider settings = SettingsProvider();
+
+    final NotificationAppSettings appSettings =
+        await settings.notificationGetAppSettings(evt.packageName!);
+
+    bool isPotentialMatch = false;
+    final String text = evt.text ?? "";
+
+    if (appSettings.regex != null && appSettings.regex!.isNotEmpty) {
+      isPotentialMatch = RegExp(appSettings.regex!).hasMatch(text);
+    } else {
+      final Iterable<RegExpMatch> matches = rFindMoney.allMatches(text);
+      for (RegExpMatch match in matches) {
+        if ((match.namedGroup("postCurrency")?.isNotEmpty ?? false) ||
+            (match.namedGroup("preCurrency")?.isNotEmpty ?? false)) {
+          isPotentialMatch = true;
+          break;
+        }
+      }
+    }
+
+    if (!isPotentialMatch) {
+      log.finer(() => "nlCallback(${evt.packageName}): no match found");
+      return;
+    }
+
     await settings.notificationAddKnownApp(evt.packageName!);
 
     if (!(await settings.notificationUsedApps()).contains(evt.packageName)) {
@@ -110,31 +117,35 @@ void nlCallback() {
       return;
     }
 
-    final NotificationAppSettings appSettings = await settings
-        .notificationGetAppSettings(evt.packageName!);
     bool showNotification = true;
 
-    if (appSettings.autoAdd) {
-      tz.initializeTimeZones();
-      log.finer(
-        () => "nlCallback(${evt.packageName}): trying to auto-add transaction",
+    tz.initializeTimeZones();
+    try {
+      final FireflyService ffService = FireflyService();
+      if (!await ffService.signInFromStorage()) {
+        throw UnauthenticatedResponse;
+      }
+      final FireflyIii api = ffService.api;
+      final CurrencyRead localCurrency = ffService.defaultCurrency;
+      late CurrencyRead? currency;
+      late double amount;
+
+      (currency, amount) = await parseNotificationText(
+        api,
+        text,
+        localCurrency,
+        userRegex: appSettings.regex,
       );
-      try {
-        final FireflyService ffService = FireflyService();
-        if (!await ffService.signInFromStorage()) {
-          throw UnauthenticatedResponse;
-        }
-        final FireflyIii api = ffService.api;
-        final CurrencyRead localCurrency = ffService.defaultCurrency;
-        late CurrencyRead? currency;
-        late double amount;
 
-        (currency, amount) = await parseNotificationText(
-          api,
-          evt.text!,
-          localCurrency,
+      if (amount <= 0) {
+        log.finer(() => "nlCallback(${evt.packageName}): amount is 0");
+        return;
+      }
+
+      if (appSettings.autoAdd) {
+        log.finer(
+          () => "nlCallback(${evt.packageName}): trying to auto-add transaction",
         );
-
         // Set date
         final DateTime date =
             ffService.tzHandler
@@ -142,10 +153,7 @@ void nlCallback() {
                   DateTime.tryParse(evt.postTime ?? "") ?? DateTime.now(),
                 )
                 .toLocal();
-        String note = "";
-        if (appSettings.autoAdd) {
-          note = evt.text ?? "";
-        }
+        String note = text;
 
         // Check currency
         if (currency?.id != localCurrency.id) {
@@ -164,9 +172,7 @@ void nlCallback() {
               type: TransactionTypeProperty.withdrawal,
               date: date,
               amount: amount.toString(),
-              description: evt.title!,
-              // destinationId
-              // destinationName
+              description: evt.title ?? "Notification Transaction",
               notes: note,
               order: 0,
               sourceId: appSettings.defaultAccountId,
@@ -211,10 +217,10 @@ void nlCallback() {
         );
 
         showNotification = false;
-      } catch (e, stackTrace) {
-        log.severe("Error while auto-adding transaction", e, stackTrace);
-        showNotification = true;
       }
+    } catch (e, stackTrace) {
+      log.severe("Error while processing notification", e, stackTrace);
+      showNotification = true;
     }
 
     if (showNotification) {
@@ -239,7 +245,7 @@ void nlCallback() {
             NotificationTransaction(
               evt.packageName ?? "",
               evt.title ?? "",
-              evt.text ?? "",
+              text,
               DateTime.tryParse(evt.postTime ?? "") ?? DateTime.now(),
             ),
           ),
@@ -276,82 +282,77 @@ Future<void> nlNotificationTap(
 Future<(CurrencyRead?, double)> parseNotificationText(
   FireflyIii api,
   String notificationBody,
-  CurrencyRead localCurrency,
-) async {
+  CurrencyRead localCurrency, {
+  String? userRegex,
+}) async {
   CurrencyRead? currency;
   double amount = 0;
+  String? extractedAmountStr;
 
-  // Try to extract substrings that may (or may not) relate to spending amount
-  final Iterable<RegExpMatch> matches = rFindMoney.allMatches(notificationBody);
-
-  if (matches.isNotEmpty) {
-    final List<CurrencyRead> currencies =
-        (await api.v1CurrenciesGet()).body!.data;
-    currencies.removeWhere(
-      (CurrencyRead currency) => currency.attributes.enabled != true,
-    );
-    currencies.add(localCurrency);
-
-    int bestMatchIndex = -1;
-
-    matchesloop:
-    for (int i = 0; i < matches.length; ++i) {
-      final RegExpMatch match = matches.elementAt(i);
-
-      final bool hasPre = match.namedGroup("preCurrency")?.isNotEmpty ?? false;
-      final bool hasPost = match.namedGroup("postCurrency")!.isNotEmpty;
-
-      if (hasPre || hasPost) {
-        final String preCurrency = match.namedGroup("preCurrency")!;
-        final String postCurrency = match.namedGroup("postCurrency")!;
-
-        // If we haven't found any good match (meaning a match with some valid
-        // pre or post currency) then we should regard the current one as the
-        // best one so far
-        if (bestMatchIndex == -1) {
-          bestMatchIndex = i;
-        }
-
-        for (CurrencyRead apiCurrency in currencies) {
-          if (apiCurrency.attributes.code == preCurrency ||
-              apiCurrency.attributes.symbol == preCurrency ||
-              apiCurrency.attributes.code == postCurrency ||
-              apiCurrency.attributes.symbol == postCurrency) {
-            bestMatchIndex = i;
-            currency = apiCurrency;
-            break matchesloop;
-          }
-        }
+  // Prioritizes userRegex
+  if (userRegex != null && userRegex.isNotEmpty) {
+    final RegExp reg = RegExp(userRegex);
+    final RegExpMatch? match = reg.firstMatch(notificationBody);
+    if (match != null) {
+      extractedAmountStr = match.namedGroup("amount");
+      if (extractedAmountStr == null && match.groupCount > 0) {
+        extractedAmountStr = match.group(1);
       }
     }
+  } else {
+    // Fallback to legacy
+    final Iterable<RegExpMatch> matches = rFindMoney.allMatches(notificationBody);
 
-    if (bestMatchIndex != -1) {
-      final RegExpMatch bestMatch = matches.elementAt(bestMatchIndex);
+    if (matches.isNotEmpty) {
+      final List<CurrencyRead> currencies =
+          (await api.v1CurrenciesGet()).body!.data;
+      currencies.removeWhere((c) => c.attributes.enabled != true);
+      currencies.add(localCurrency);
 
-      String amountStr = (bestMatch.namedGroup("amount") ?? "").replaceAll(
-        RegExp(r"\s+"),
-        "",
-      );
+      int bestMatchIndex = -1;
+      for (int i = 0; i < matches.length; ++i) {
+        final RegExpMatch match = matches.elementAt(i);
+        final String pre = match.namedGroup("preCurrency") ?? "";
+        final String post = match.namedGroup("postCurrency") ?? "";
 
-      if (amountStr.isNotEmpty) {
-        // Find the first non-digit character at the end of the string
-        String separator = amountStr[0];
-        for (int i = amountStr.length - 1; i >= 0; i--) {
-          separator = amountStr[i];
-          if (!RegExp(r'\d').hasMatch(separator)) {
-            break;
+        if (pre.isNotEmpty || post.isNotEmpty) {
+          if (bestMatchIndex == -1) bestMatchIndex = i;
+          for (CurrencyRead apiCurrency in currencies) {
+            if (apiCurrency.attributes.code == pre ||
+                apiCurrency.attributes.symbol == pre ||
+                apiCurrency.attributes.code == post ||
+                apiCurrency.attributes.symbol == post) {
+              bestMatchIndex = i;
+              currency = apiCurrency;
+              break;
+            }
           }
+          if (currency != null) break;
         }
-
-        // Strip all non-digit characters that are not decimal separators
-        if (separator == "." || separator == ",") {
-          amountStr = amountStr.replaceAll(RegExp('[^0-9$separator]'), '');
-        }
-
-        amount = double.tryParse(amountStr.replaceAll(",", "."))!;
+      }
+      if (bestMatchIndex != -1) {
+        extractedAmountStr =
+            matches.elementAt(bestMatchIndex).namedGroup("amount");
       }
     }
   }
 
-  return (currency, amount);
+  String? cleanAmount;
+  if (extractedAmountStr != null) {
+    cleanAmount = extractedAmountStr.replaceAll(RegExp(r'[^0-9.,]'), '');
+
+    if (cleanAmount.isNotEmpty) {
+      cleanAmount = cleanAmount.replaceAll(',', '.');
+
+      if ('.'.allMatches(cleanAmount).length > 1) {
+        int lastDotIndex = cleanAmount.lastIndexOf('.');
+        String beforeDot = cleanAmount.substring(0, lastDotIndex).replaceAll('.', '');
+        String afterDot = cleanAmount.substring(lastDotIndex + 1);
+        cleanAmount = '$beforeDot.$afterDot';
+      }
+      amount = double.tryParse(cleanAmount) ?? 0.0;
+    }
+  }
+
+  return (currency ?? localCurrency, amount);
 }

--- a/lib/pages/settings/notifications.dart
+++ b/lib/pages/settings/notifications.dart
@@ -298,10 +298,23 @@ class AppCard extends StatefulWidget {
 }
 
 class _AppCardState extends State<AppCard> {
+  late TextEditingController regexController;
   final TextEditingController accountTextController = TextEditingController();
   final FocusNode accountFocusNode = FocusNode();
 
   String? appAccountId;
+  
+  @override
+  void initState() {
+    super.initState();
+    regexController = TextEditingController(text: widget.settings.regex);
+  }
+  @override
+  void dispose() {
+    regexController.dispose();
+    // accountFocusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -417,6 +430,24 @@ class _AppCardState extends State<AppCard> {
                             widget.app,
                             widget.settings,
                           );
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  // Regex field
+                  TextFormField(
+                    controller: regexController,
+                    decoration: InputDecoration(
+                      label: const Text("Regex"),
+                      icon: const Icon(Icons.code),
+                      border: const OutlineInputBorder(),
+                      hintText: "Leave blank to use general regex method",
+                    ),
+                    onChanged: (String value) async {
+                      widget.settings.regex = value.isEmpty ? null : value;
+                      await context.read<SettingsProvider>().notificationSetAppSettings(
+                        widget.app,
+                        widget.settings,
+                      );
                     },
                   ),
                 ],

--- a/lib/pages/transaction.dart
+++ b/lib/pages/transaction.dart
@@ -369,18 +369,17 @@ class _TransactionPageState extends State<TransactionPage>
           late CurrencyRead? currency;
           late double amount;
 
+          final NotificationAppSettings appSettings = await settings
+              .notificationGetAppSettings(widget.notification!.appName);
+
           (currency, amount) = await parseNotificationText(
             api,
             widget.notification!.body,
             _localCurrency!,
+            userRegex: appSettings.regex,
           );
-
-          // Fallback solution
-          currency ??= defaultCurrency;
-
+          
           // Title & Note
-          final NotificationAppSettings appSettings = await settings
-              .notificationGetAppSettings(widget.notification!.appName);
           if (appSettings.includeTitle) {
             _titleTextController.text = widget.notification!.title;
           } else {
@@ -388,6 +387,9 @@ class _TransactionPageState extends State<TransactionPage>
             _noteTextControllers[0].text =
                 "${widget.notification!.title} - ${_noteTextControllers[0].text}";
           }
+
+          // Fallback solution
+          currency ??= defaultCurrency;
 
           if (!appSettings.emptyNote) {
             _noteTextControllers[0].text = widget.notification!.body;

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -24,6 +24,7 @@ class NotificationAppSettings {
     this.includeTitle = true,
     this.autoAdd = false,
     this.emptyNote = false,
+    this.regex,
   });
 
   final String appName;
@@ -31,13 +32,15 @@ class NotificationAppSettings {
   bool includeTitle = true;
   bool autoAdd = false;
   bool emptyNote = false;
+  String? regex;
 
   NotificationAppSettings.fromJson(Map<String, dynamic> json)
     : appName = json['appName'],
       defaultAccountId = json['defaultAccountId'],
       includeTitle = json['includeTitle'] ?? true,
       autoAdd = json['autoAdd'] ?? false,
-      emptyNote = json['emptyNote'] ?? false;
+      emptyNote = json['emptyNote'] ?? false,
+      regex = json['regex'];
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     'appName': appName,
@@ -45,6 +48,7 @@ class NotificationAppSettings {
     'includeTitle': includeTitle,
     'autoAdd': autoAdd,
     'emptyNote': emptyNote,
+    'regex': regex,
   };
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: waterflyiii
 description: Waterfly III, a mobile client for Firefly III
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.1.10
 
 environment:
-  sdk: '>=3.7.0 <4.0.0'
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -43,7 +43,7 @@ dependencies:
   flutter_email_sender: ^8.0.0
   local_auth: ^3.0.0
   dynamic_color: ^1.7.0
-  material_color_utilities: ^0.11.1
+  material_color_utilities: ^0.13.0
   version: ^3.0.2
   quick_actions: ^1.0.7
   stock: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.0
+  rename: ^3.1.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Allow users to set their very own regex in the notification listener, fall back to the legacy regex if not set.

Example:
```
已支付\s*(?<amount>\d+\.?\d{0,2})元
```

Screenshot:
<img width="1216" height="2504" alt="image" src="https://github.com/user-attachments/assets/646dea4a-cbd7-42b2-85bf-d4e80b2d6308" />
